### PR TITLE
Add safety checks and send empty array when error

### DIFF
--- a/components/GetColors.coffee
+++ b/components/GetColors.coffee
@@ -35,6 +35,9 @@ exports.getComponent = ->
     forwardGroups: yes
     async: yes
   , (data, groups, out, callback) ->
+    unless data?.height? > 0 and data?.width? > 0
+      return callback new Error "Error when trying to get colors: canvas is undefined."
+
     c.params.colors = 10 unless c.params.colors?
     c.params.method = 1 unless c.params.method?
     try
@@ -51,7 +54,11 @@ exports.getComponent = ->
       if c.params.css
         colors = colors.map (color) -> "rgb(#{color[0]}, #{color[1]}, #{color[2]})"
     catch e
-      return callback new Error "Error when trying to get colors: #{e}"
+      out.canvas.send data
+      out.colors.send []
+      console.warn "Error when trying to get colors: #{e} Sending an empty array."
+      do callback
+      return
     out.canvas.send data
     out.colors.send colors
     do callback

--- a/spec/GetColors.coffee
+++ b/spec/GetColors.coffee
@@ -148,11 +148,12 @@ describe 'GetColors component', ->
         ins.send canvas
         ins.endGroup()
   describe 'when given a small image', ->
-    it 'should return an error', (done) ->
+    it 'should return an empty array', (done) ->
       input = '1x1.gif'
       id = null
-      error.on "data", (err) ->
-        chai.expect(err).to.be.an 'object'
+      colors.once "data", (colors) ->
+        chai.expect(colors).to.be.an 'array'
+        chai.expect(colors).to.have.length 0
         done()
       id = getCanvasWithImage input, (canvas) ->
         ins.send canvas


### PR DESCRIPTION
- Send `error` when canvas received is `undefined`.
- Send `empty canvas` and do a `console.warn` when error when building the `pallete`. 