### PR TITLE
Verify full scale URL before replacing the original URL for it

### DIFF
--- a/components/ToFullscale.coffee
+++ b/components/ToFullscale.coffee
@@ -101,18 +101,22 @@ exports.getComponent = ->
     if url.match /[-_](small|thumb)/
       newUrl = tryFindingFullscale url, callback
 
-    # Verify that the newUrl exists
-    superagent.head newUrl
-    .redirects(1)
-    .end (err, res) ->
-      # If the response is not 200, send the original URL
-      unless res and res.statusCode is 200
-        out.send url
+    if newUrl isnt url
+      # Verify that the newUrl exists
+      superagent.head newUrl
+      .redirects(1)
+      .end (err, res) ->
+        # If the response is not 200, send the original URL
+        unless res and res.statusCode is 200
+          out.send url
+          do callback
+          return
+        # Use redirection URL
+        if res.redirects?.length > 0
+          newUrl = tryRedirect url, res.redirects[0]
+        out.send newUrl
         do callback
-        return
-      # Use redirection URL
-      if res.redirects?.length > 0
-        newUrl = tryRedirect url, res.redirects[0]
-      out.send newUrl
+    else
+      out.send url
       do callback
   c

--- a/components/ToFullscale.coffee
+++ b/components/ToFullscale.coffee
@@ -105,15 +105,14 @@ exports.getComponent = ->
     superagent.head newUrl
     .redirects(1)
     .end (err, res) ->
-      return callback err if err
-      # If the newUrl exists, send it
-      if res and res.statusCode is 200
-        # Use redirection URL
-        if res.redirects?.length > 0
-          newUrl = tryRedirect url, res.redirects[0]
-        out.send newUrl
-      # Otherwise, keep the original one
-      else
+      # If the response is not 200, send the original URL
+      unless res and res.statusCode is 200
         out.send url
-      callback null
+        do callback
+        return
+      # Use redirection URL
+      if res.redirects?.length > 0
+        newUrl = tryRedirect url, res.redirects[0]
+      out.send newUrl
+      do callback
   c

--- a/components/ToFullscale.coffee
+++ b/components/ToFullscale.coffee
@@ -96,7 +96,9 @@ exports.getComponent = ->
 
     # Verify that the newUrl exists
     superagent.head newUrl
+    .redirects(1)
     .end (err, res) ->
+      newUrl = res.request?.uri?.href ? newUrl
       return callback err if err
       console.log 'URL', url
       console.log 'new URL', newUrl

--- a/components/ToFullscale.coffee
+++ b/components/ToFullscale.coffee
@@ -108,8 +108,10 @@ exports.getComponent = ->
     .end (err, res) ->
       return callback err if err
       # If the newUrl exists, send it
-      return newUrl if res and res.statusCode is 200
+      if res and res.statusCode is 200
+        out.send newUrl
       # Otherwise, keep the original one
-      out.send url
+      else
+        out.send url
       callback null
   c

--- a/components/ToFullscale.coffee
+++ b/components/ToFullscale.coffee
@@ -98,6 +98,9 @@ exports.getComponent = ->
     superagent.head newUrl
     .end (err, res) ->
       return callback err if err
+      console.log 'URL', url
+      console.log 'new URL', newUrl
+      console.log 'status', res.statusCode
       # If the newUrl exists, send it
       if res and res.statusCode is 200
         out.send newUrl

--- a/components/ToFullscale.coffee
+++ b/components/ToFullscale.coffee
@@ -55,8 +55,9 @@ tryFindingFullscale = (url) ->
 
 # Flickr redirects to a photo_unavailable image if the new URL do not exists
 tryRedirect = (original, redirected) ->
-  return redirected unless redirected.indexOf('staticflickr.com') isnt -1
-  return original if redirected.match /photo_unavailable/
+  if (original.indexOf('staticflickr.com') isnt -1) and
+  (redirected.indexOf('photo_unavailable') isnt -1)
+    return original
   return redirected
 
 exports.getComponent = ->
@@ -105,15 +106,11 @@ exports.getComponent = ->
     .redirects(1)
     .end (err, res) ->
       return callback err if err
-      console.log 'URL', url
-      console.log 'new URL', newUrl
-      console.log 'status', res.statusCode
-      console.log 'res.redirects', res.redirects
       # If the newUrl exists, send it
       if res and res.statusCode is 200
         # Use redirection URL
-        if res.redirects?
-          newUrl = tryRedirect res.redirects[0], url
+        if res.redirects?.length > 0
+          newUrl = tryRedirect url, res.redirects[0]
         out.send newUrl
       # Otherwise, keep the original one
       else

--- a/components/ToFullscale.coffee
+++ b/components/ToFullscale.coffee
@@ -51,16 +51,7 @@ convertGravatar = (url) ->
   return URI.build parts
 
 tryFindingFullscale = (url, out, callback) ->
-  # Convert
-  newUrl = url
-  fullUrl = url.replace /[-_](small|thumbnail|thumb|tm)/, ''
-  # Verify that it exists
-  superagent.head fullUrl
-  .end (err, res) ->
-    return callback err if err
-    newUrl = fullUrl if res and res.statusCode is 200
-    out.send newUrl
-    callback null
+  return url.replace /[-_](small|thumbnail|thumb|tm)/, ''
 
 exports.getComponent = ->
   c = new noflo.Component
@@ -101,7 +92,7 @@ exports.getComponent = ->
       newUrl = convertGravatar url, callback
 
     if url.match /[-_](small|thumb)/
-      return tryFindingFullscale url, out, callback
+      newUrl = tryFindingFullscale url, callback
 
     # Verify that the newUrl exists
     superagent.head newUrl

--- a/components/ToFullscale.coffee
+++ b/components/ToFullscale.coffee
@@ -5,6 +5,8 @@ unless noflo.isBrowser()
 else
   URI = require 'URIjs'
 
+timeout_HEAD = 15000
+
 convertFlickr = (url) ->
   # See docs in https://www.flickr.com/services/api/misc.urls.html
   format = url.match /_(.)\.(gif|png|jpg)/
@@ -105,6 +107,7 @@ exports.getComponent = ->
       # Verify that the newUrl exists
       superagent.head newUrl
       .redirects(1)
+      .timeout(timeout_HEAD)
       .end (err, res) ->
         # If the response is not 200, send the original URL
         unless res and res.statusCode is 200

--- a/components/ToFullscale.coffee
+++ b/components/ToFullscale.coffee
@@ -103,6 +103,13 @@ exports.getComponent = ->
     if url.match /[-_](small|thumb)/
       return tryFindingFullscale url, out, callback
 
-    out.send newUrl
-    callback null
+    # Verify that the newUrl exists
+    superagent.head newUrl
+    .end (err, res) ->
+      return callback err if err
+      # If the newUrl exists, send it
+      return newUrl if res and res.statusCode is 200
+      # Otherwise, keep the original one
+      out.send url
+      callback null
   c

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "read-chunk": "^2.0.0",
     "request": "^2.69.0",
     "rgbquant": "1.1.2",
-    "superagent": "0.21.0",
+    "superagent": "2.2.0",
     "temporary": "0.0.8",
     "urijs": "^1.17.0"
   },

--- a/spec/ToFullscale.coffee
+++ b/spec/ToFullscale.coffee
@@ -5,7 +5,7 @@ unless noflo.isBrowser()
 else
   ToFullscale = require 'noflo-image/components/ToFullscale.js'
 
-describe 'ToFullscale component', ->
+describe.only 'ToFullscale component', ->
   c = null
   url = null
   newUrl = null

--- a/spec/ToFullscale.coffee
+++ b/spec/ToFullscale.coffee
@@ -6,7 +6,7 @@ else
   ToFullscale = require 'noflo-image/components/ToFullscale.js'
 
 describe 'ToFullscale component', ->
-  @timeout 5*1000
+  @timeout 10*1000
   c = null
   url = null
   newUrl = null

--- a/spec/ToFullscale.coffee
+++ b/spec/ToFullscale.coffee
@@ -6,7 +6,7 @@ else
   ToFullscale = require 'noflo-image/components/ToFullscale.js'
 
 describe 'ToFullscale component', ->
-  @timeout 10*1000
+  @timeout 20*1000
   c = null
   url = null
   newUrl = null

--- a/spec/ToFullscale.coffee
+++ b/spec/ToFullscale.coffee
@@ -28,6 +28,7 @@ describe 'ToFullscale component', ->
         url.send 'http://www.esa.int/var/esa/storage/images/esa_multimedia/images/2014/04/glowing_jewels_in_the_galactic_plane/14491843-1-eng-GB/Glowing_jewels_in_the_Galactic_Plane.jpg'
 
     describe 'with Flickr images', ->
+      @timeout 5*1000
       it 'should return correct URL for non-sized', (done) ->
         newUrl.on 'data', (image) ->
           chai.expect(image).to.equal 'https://farm8.staticflickr.com/7395/12952090783_ce023450da_b.jpg'
@@ -53,6 +54,11 @@ describe 'ToFullscale component', ->
           chai.expect(image).to.equal 'https://farm4.staticflickr.com/3493/3961596996_c9fb5c5e00_o.png'
           done()
         url.send 'https://farm4.staticflickr.com/3493/3961596996_c9fb5c5e00_o_d.png'
+      it 'should return the same URL for and old image', (done) ->
+        newUrl.on 'data', (image) ->
+          chai.expect(image).to.equal 'https://farm4.staticflickr.com/3493/3961596996_367327afd9.jpg'
+          done()
+        url.send 'https://farm4.staticflickr.com/3493/3961596996_367327afd9.jpg'
 
     describe 'with WordPress.com images', ->
       it 'should return correct URL for non-sized', (done) ->

--- a/spec/ToFullscale.coffee
+++ b/spec/ToFullscale.coffee
@@ -63,7 +63,7 @@ describe 'ToFullscale component', ->
     describe 'with WordPress.com images', ->
       it 'should return correct URL for non-sized', (done) ->
         newUrl.on 'data', (image) ->
-          chai.expect(image).to.equal 'https://tctechcrunch2011.files.wordpress.com/2013/07/henri-bergius3.jpg'
+          chai.expect(image).to.equal 'http://tctechcrunch2011.files.wordpress.com/2013/07/henri-bergius3.jpg'
           done()
         url.send 'http://tctechcrunch2011.files.wordpress.com/2013/07/henri-bergius3.jpg'
       it 'should return correct URL for thumbnails', (done) ->
@@ -89,7 +89,7 @@ describe 'ToFullscale component', ->
     describe 'with Wikimedia Commons thumbnails', ->
       it 'should return correct URL for non-sized', (done) ->
         newUrl.on 'data', (image) ->
-          chai.expect(image).to.equal 'https://upload.wikimedia.org/wikipedia/commons/7/7a/India_-_Varanasi_green_peas_-_2714.jpg'
+          chai.expect(image).to.equal 'http://upload.wikimedia.org/wikipedia/commons/7/7a/India_-_Varanasi_green_peas_-_2714.jpg'
           done()
         url.send 'http://upload.wikimedia.org/wikipedia/commons/7/7a/India_-_Varanasi_green_peas_-_2714.jpg'
       it 'should return correct URL for thumbnails', (done) ->

--- a/spec/ToFullscale.coffee
+++ b/spec/ToFullscale.coffee
@@ -5,7 +5,8 @@ unless noflo.isBrowser()
 else
   ToFullscale = require 'noflo-image/components/ToFullscale.js'
 
-describe.only 'ToFullscale component', ->
+describe 'ToFullscale component', ->
+  @timeout 5*1000
   c = null
   url = null
   newUrl = null
@@ -28,7 +29,6 @@ describe.only 'ToFullscale component', ->
         url.send 'http://www.esa.int/var/esa/storage/images/esa_multimedia/images/2014/04/glowing_jewels_in_the_galactic_plane/14491843-1-eng-GB/Glowing_jewels_in_the_Galactic_Plane.jpg'
 
     describe 'with Flickr images', ->
-      @timeout 5*1000
       it 'should return correct URL for non-sized', (done) ->
         newUrl.on 'data', (image) ->
           chai.expect(image).to.equal 'https://farm8.staticflickr.com/7395/12952090783_ce023450da_b.jpg'
@@ -63,12 +63,12 @@ describe.only 'ToFullscale component', ->
     describe 'with WordPress.com images', ->
       it 'should return correct URL for non-sized', (done) ->
         newUrl.on 'data', (image) ->
-          chai.expect(image).to.equal 'http://tctechcrunch2011.files.wordpress.com/2013/07/henri-bergius3.jpg'
+          chai.expect(image).to.equal 'https://tctechcrunch2011.files.wordpress.com/2013/07/henri-bergius3.jpg'
           done()
         url.send 'http://tctechcrunch2011.files.wordpress.com/2013/07/henri-bergius3.jpg'
       it 'should return correct URL for thumbnails', (done) ->
         newUrl.on 'data', (image) ->
-          chai.expect(image).to.equal 'http://tctechcrunch2011.files.wordpress.com/2013/07/henri-bergius3.jpg'
+          chai.expect(image).to.equal 'https://tctechcrunch2011.files.wordpress.com/2013/07/henri-bergius3.jpg'
           done()
         url.send 'http://tctechcrunch2011.files.wordpress.com/2013/07/henri-bergius3.jpg?w=400'
 
@@ -89,17 +89,17 @@ describe.only 'ToFullscale component', ->
     describe 'with Wikimedia Commons thumbnails', ->
       it 'should return correct URL for non-sized', (done) ->
         newUrl.on 'data', (image) ->
-          chai.expect(image).to.equal 'http://upload.wikimedia.org/wikipedia/commons/7/7a/India_-_Varanasi_green_peas_-_2714.jpg'
+          chai.expect(image).to.equal 'https://upload.wikimedia.org/wikipedia/commons/7/7a/India_-_Varanasi_green_peas_-_2714.jpg'
           done()
         url.send 'http://upload.wikimedia.org/wikipedia/commons/7/7a/India_-_Varanasi_green_peas_-_2714.jpg'
       it 'should return correct URL for thumbnails', (done) ->
         newUrl.on 'data', (image) ->
-          chai.expect(image).to.equal 'http://upload.wikimedia.org/wikipedia/commons/7/7a/India_-_Varanasi_green_peas_-_2714.jpg'
+          chai.expect(image).to.equal 'https://upload.wikimedia.org/wikipedia/commons/7/7a/India_-_Varanasi_green_peas_-_2714.jpg'
           done()
         url.send 'http://upload.wikimedia.org/wikipedia/commons/thumb/7/7a/India_-_Varanasi_green_peas_-_2714.jpg/700px-India_-_Varanasi_green_peas_-_2714.jpg'
       it 'should return correct URL for thumbnails with escaped characters', (done) ->
         newUrl.on 'data', (image) ->
-          chai.expect(image).to.equal 'http://upload.wikimedia.org/wikipedia/commons/1/1f/Vistas_desde_la_iglesia_de_San_Pedro%2C_Riga%2C_Letonia%2C_2012-08-07%2C_DD_01.JPG'
+          chai.expect(image).to.equal 'https://upload.wikimedia.org/wikipedia/commons/1/1f/Vistas_desde_la_iglesia_de_San_Pedro%2C_Riga%2C_Letonia%2C_2012-08-07%2C_DD_01.JPG'
           done()
         url.send 'http://upload.wikimedia.org/wikipedia/commons/thumb/1/1f/Vistas_desde_la_iglesia_de_San_Pedro%2C_Riga%2C_Letonia%2C_2012-08-07%2C_DD_01.JPG/1000px-Vistas_desde_la_iglesia_de_San_Pedro%2C_Riga%2C_Letonia%2C_2012-08-07%2C_DD_01.JPG'
 


### PR DESCRIPTION
This was motivated because some URLs from Flickr are redirecting the `_b` version to a photo indicating that is invalid (status code of 200 for https://s.yimg.com/pw/images/en-us/photo_unavailable_l.png).
- Verify full scale URL before replacing the original URL for it;
- Increase tests timeout;
- Use 2.2.0 version of superagent.